### PR TITLE
Fix build error caused by bundle install failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "9.0"
+      xcode: "10.0.0"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output


### PR DESCRIPTION
Fix bundle install failure (which is caused by an issue with connecting to https://rubygems.org/) by using a newer VM image which would have a newer version of openssl installed
See: https://bundler.io/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html#why-am-i-seeing-read-server-hello-a